### PR TITLE
fix(ci): replace broken quay.io/buildstream image with bst2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
     name: BuildStream Validate
     runs-on: ubuntu-latest
     container:
-      image: quay.io/buildstream/buildstream:latest
+      image: registry.gitlab.com/freedesktop-sdk/infrastructure/freedesktop-sdk-docker-images/bst2:64eb0b4930d57a92710822898fb73af6cc1ae35d
     steps:
       - uses: actions/checkout@v4  # v4
       - name: Validate .bst elements


### PR DESCRIPTION
The `BuildStream Validate` job in `test.yml` pulls `quay.io/buildstream/buildstream:latest`, which fails with `unauthorized` (confirmed: fails the same way on `main`, unrelated to any specific PR).

Traced the correct image by checking how projectbluefin/dakota's Justfile invokes BuildStream — it uses `registry.gitlab.com/freedesktop-sdk/infrastructure/freedesktop-sdk-docker-images/bst2`. Turns out this repo's own `build-buildgrid.yml` and `build-tromso-multirunner.yml` already use that exact image pinned to digest `64eb0b4930d57a92710822898fb73af6cc1ae35d` — `test.yml`'s validate job was just never updated to match.

Verified locally: pulled both the floating tag and the pinned digest, ran `bst --version` successfully in the container (BuildStream 2.7.0).